### PR TITLE
Use Virtual Lines; evaluate all lines on <CR>;  Add Icons;  Add reset buffer option

### DIFF
--- a/lua/nvumi/main.lua
+++ b/lua/nvumi/main.lua
@@ -13,10 +13,14 @@ local function run_numi_on_buffer()
         stdout_buffered = true,
         on_stdout = function(_, data)
           if data and #data > 0 then
+            local result = table.concat(data, " ")
+            local virt_lines = {}
+            for _, txt in ipairs(vim.split(result, "\n")) do
+              table.insert(virt_lines, { { " " .. txt, "Comment" } })
+            end
             vim.schedule(function()
               vim.api.nvim_buf_set_extmark(buf, ns, line_nr - 1, 0, {
-                virt_text = { { " = " .. table.concat(data, " "), "Comment" } },
-                virt_text_pos = "eol",
+                virt_lines = virt_lines,
               })
             end)
           end
@@ -37,7 +41,6 @@ function M.open()
             "<CR>",
             function()
               run_numi_on_buffer()
-              vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, false, true), "n", false)
             end,
             mode = { "n", "x" },
           },

--- a/lua/nvumi/main.lua
+++ b/lua/nvumi/main.lua
@@ -15,7 +15,7 @@ local function run_numi_on_buffer()
           if data and #data > 0 then
             local virt_lines = {}
             for _, txt in ipairs(vim.split(table.concat(data, " "), "\n")) do
-              table.insert(virt_lines, { { "  " .. txt, "Comment" } })
+              table.insert(virt_lines, { { " " .. txt, "Comment" } })
             end
             vim.schedule(function()
               vim.api.nvim_buf_set_extmark(buf, ns, i - 1, 0, { virt_lines = virt_lines })
@@ -38,6 +38,7 @@ function M.open()
   require("snacks.scratch").open({
     name = "Nvumi",
     ft = "nvumi",
+    icon = "",
     win_by_ft = {
       nvumi = {
         keys = {
@@ -53,6 +54,11 @@ function M.setup()
   vim.api.nvim_create_user_command("Nvumi", function()
     M.open()
   end, {})
+  require("nvim-web-devicons").set_icon({
+    nvumi = {
+      icon = "",
+    },
+  })
 end
 
 return M

--- a/lua/nvumi/main.lua
+++ b/lua/nvumi/main.lua
@@ -15,7 +15,7 @@ local function run_numi_on_buffer()
           if data and #data > 0 then
             local virt_lines = {}
             for _, txt in ipairs(vim.split(table.concat(data, " "), "\n")) do
-              table.insert(virt_lines, { { " " .. txt, "Comment" } })
+              table.insert(virt_lines, { { "  " .. txt, "Comment" } })
             end
             vim.schedule(function()
               vim.api.nvim_buf_set_extmark(buf, ns, i - 1, 0, { virt_lines = virt_lines })
@@ -27,6 +27,13 @@ local function run_numi_on_buffer()
   end
 end
 
+local function reset_buffer()
+  local buf = vim.api.nvim_get_current_buf()
+  local ns = vim.api.nvim_create_namespace("nvumi_inline")
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, {})
+  vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
+end
+
 function M.open()
   require("snacks.scratch").open({
     name = "Nvumi",
@@ -34,7 +41,8 @@ function M.open()
     win_by_ft = {
       nvumi = {
         keys = {
-          ["source"] = { "<CR>", run_numi_on_buffer, mode = { "n", "x" }, desc = "Run numi" },
+          ["source"] = { "<CR>", run_numi_on_buffer, mode = { "n", "x" }, desc = "Run Numi" },
+          ["reset"] = { "R", reset_buffer, mode = "n", desc = "Reset buffer" },
         },
       },
     },


### PR DESCRIPTION
- Switch from inline `virt_text` to `virt_lines`: results appear on a new line beneath each evaluated line
- Update the evaluation function to process all non-empty lines in the buffer (not just the line under the cursor)
- Added reset buffer keybind <R> for clearing the buffer and evaluations
- Added an icon for the Nvumi buffer
- Configured the icon using nvim-web-devicons (so it shows in the list of buffers)
- Small refactor