### PR TITLE
Add opts table; allow customising position of virtual text

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 ![Screenshot 2025-02-13 at 16 26 04](https://github.com/user-attachments/assets/db676c0f-e191-43ad-8c14-909e3ce7302d)
 
-
-
 ## Installation
 
 ### Using Lazy.nvim
@@ -14,7 +12,9 @@
 {
   "josephburgess/nvumi",
   dependencies = { "folke/snacks.nvim" },
-  opts = {}
+  opts = {
+    virtual_text = "inline" -- or "newline"
+  }
 }
 ```
 
@@ -26,12 +26,12 @@
 2. **Enter Your Calculation:**
    In the scratch buffer, type your natural language expression (e.g., `20 inches in cm`) in insert mode.
 
-3. **Evaluate the Expression:**
-   Press `<CR>` (Enter) on the line you wish to evaluate, the answer will be displayed in virtual text.
+3. **Evaluate:**
+   Press `<CR>` (Enter) and the buffer will attempt to evaluate all non-empty lines
 
 ## Configuration
 
-TBC
+Currently you can configure where you want the virtual text to be displayed, `inline` or `newline`
 
 ## Requirements
 
@@ -61,7 +61,7 @@ MIT License. See [LICENSE](LICENSE) for details.
 
 ## Acknowledgements
 
+- **[Snacks.nvim](https://github.com/folke/snacks.nvim):**
+  Folke needs no introduction given his super-human contributions to the community. The `lua` code runner built into the Scratch buffer inspired this idea in the first place.
 - **[numi](https://github.com/nikolaeu/numi):**
   Thanks for providing an amazing natural language calculator.
-- **[Snacks.nvim](https://github.com/folke/snacks.nvim):**
-  Folke needs no introduction given his super-human contributions to the community over the years. The lua code runner built into the Scratch buffer inspired this idea in the first place.

--- a/lua/nvumi/config.lua
+++ b/lua/nvumi/config.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 M.options = {
-  -- options_tbc = "default",
+  virtual_text = "newline", -- or "inline"
 }
 
 function M.setup(user_opts)

--- a/lua/nvumi/init.lua
+++ b/lua/nvumi/init.lua
@@ -1,7 +1,9 @@
+local config = require("nvumi.config")
 local main = require("nvumi.main")
 local M = {}
 
-function M.setup()
+function M.setup(user_config)
+  config.setup(user_config)
   main.setup()
 end
 

--- a/lua/nvumi/main.lua
+++ b/lua/nvumi/main.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local function run_numi_on_buffer()
+  local config = require("nvumi.config").options
   local buf = vim.api.nvim_get_current_buf()
   local ns = vim.api.nvim_create_namespace("nvumi_inline")
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
@@ -13,12 +14,19 @@ local function run_numi_on_buffer()
         stdout_buffered = true,
         on_stdout = function(_, data)
           if data and #data > 0 then
-            local virt_lines = {}
-            for _, txt in ipairs(vim.split(table.concat(data, " "), "\n")) do
-              table.insert(virt_lines, { { " " .. txt, "Comment" } })
-            end
             vim.schedule(function()
-              vim.api.nvim_buf_set_extmark(buf, ns, i - 1, 0, { virt_lines = virt_lines })
+              if config.virtual_text == "inline" then
+                vim.api.nvim_buf_set_extmark(buf, ns, i - 1, 0, {
+                  virt_text = { { " = " .. table.concat(data, " "), "Comment" } },
+                  virt_text_pos = "eol",
+                })
+              else
+                local virt_lines = {}
+                for _, txt in ipairs(vim.split(table.concat(data, " "), "\n")) do
+                  table.insert(virt_lines, { { " " .. txt, "Comment" } })
+                end
+                vim.api.nvim_buf_set_extmark(buf, ns, i - 1, 0, { virt_lines = virt_lines })
+              end
             end)
           end
         end,
@@ -54,6 +62,7 @@ function M.setup()
   vim.api.nvim_create_user_command("Nvumi", function()
     M.open()
   end, {})
+
   require("nvim-web-devicons").set_icon({
     nvumi = {
       icon = "",


### PR DESCRIPTION
Add `virtual_text` to opts table - allows for choosing position of virtual text as `inline` after the expression or `newline` below