### PR TITLE
Revert to R as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     virtual_text = "newline", -- or "inline"
     keys = {
       run = "<CR>", -- run calculations
-      reset = "<C-r>", -- reset buffer
+      reset = "R", -- reset buffer
     },
   }
 }

--- a/doc/nvumi.txt
+++ b/doc/nvumi.txt
@@ -36,7 +36,7 @@ This is set during the plugin setup. For example, using Lazy.nvim:
 	virtual_text = "inline", -- or "newline"
 	keys = {
 	  run = "<CR>", -- run calculations
-	  reset = "<C-r>", -- reset buffer
+	  reset = "R", -- reset buffer
 	}
       }
   }

--- a/lua/nvumi/config.lua
+++ b/lua/nvumi/config.lua
@@ -4,7 +4,7 @@ M.options = {
   virtual_text = "newline", -- or "inline"
   keys = {
     run = "<CR>", -- run calculations
-    reset = "<C-r>", -- reset buffer
+    reset = "R", -- reset buffer
   },
 }
 

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -6,7 +6,7 @@ describe("nvumi.config", function()
       virtual_text = "newline",
       keys = {
         run = "<CR>",
-        reset = "<C-r>",
+        reset = "R",
       },
     }
   end)
@@ -22,12 +22,12 @@ describe("nvumi.config", function()
 
   it("should have default keys", function()
     assert.are.same("<CR>", config.options.keys.run)
-    assert.are.same("<C-r>", config.options.keys.reset)
+    assert.are.same("R", config.options.keys.reset)
   end)
 
   it("should override keys when setup is called", function()
-    config.setup({ keys = { run = "<Enter>", reset = "R" } })
+    config.setup({ keys = { run = "<Enter>", reset = "<C-r>" } })
     assert.are.same("<Enter>", config.options.keys.run)
-    assert.are.same("R", config.options.keys.reset)
+    assert.are.same("<C-r>", config.options.keys.reset)
   end)
 end)


### PR DESCRIPTION
I was tired and set a very unsensible default
Keeping it as R - this is the default in scratch core for a reason!