### PR TITLE
feat: no rerendering if values dont change

### DIFF
--- a/lua/nvumi/actions.lua
+++ b/lua/nvumi/actions.lua
@@ -14,7 +14,6 @@ end
 function M.run_on_buffer()
   local ctx = create_ctx()
   local lines = vim.api.nvim_buf_get_lines(ctx.buf, 0, -1, false)
-  vim.api.nvim_buf_clear_namespace(ctx.buf, ctx.ns, 0, -1)
   processor.process_lines(ctx, lines, 1)
 end
 
@@ -22,7 +21,6 @@ function M.run_on_line()
   local ctx = create_ctx()
   local row, _ = unpack(vim.api.nvim_win_get_cursor(0))
   local line = vim.api.nvim_get_current_line()
-  vim.api.nvim_buf_clear_namespace(ctx.buf, ctx.ns, row - 1, row)
   processor.process_line(ctx, line, row, function() end)
 end
 

--- a/lua/nvumi/renderer.lua
+++ b/lua/nvumi/renderer.lua
@@ -24,9 +24,15 @@ end
 ---@param ctx table           context
 ---@param line_index number   line index (0idx)
 ---@param result string       evaluation result
----@param callback? fun()     callback to run once finished rendering (if there's still more lines to process)
+---@param callback fun()     callback to run once finished rendering (if there's still more lines to process)
 function M.render_result(ctx, line_index, result, callback)
+  -- dont rerender if same result
+  if state.get_output(line_index) == result then
+    return callback()
+  end
+
   state.store_output(line_index, result)
+  vim.api.nvim_buf_clear_namespace(ctx.buf, ns, line_index, line_index + 1)
 
   if ctx.opts.virtual_text == "inline" then
     M.render_inline(ctx, line_index, result)
@@ -34,9 +40,7 @@ function M.render_result(ctx, line_index, result, callback)
     M.render_newline(ctx, line_index, result)
   end
 
-  if callback then
-    callback()
-  end
+  callback()
 end
 
 return M

--- a/lua/nvumi/state.lua
+++ b/lua/nvumi/state.lua
@@ -39,6 +39,10 @@ function M.get_last_output()
   return M.last_output
 end
 
+function M.get_output(line_index)
+  return M.outputs[line_index]
+end
+
 function M.clear_state()
   M.variables = {}
   M.outputs = {}

--- a/tests/renderer_spec.lua
+++ b/tests/renderer_spec.lua
@@ -1,33 +1,97 @@
 local assert = require("luassert")
-local api = vim.api
 local renderer = require("nvumi.renderer")
+local spy = require("luassert.spy")
+local state = require("nvumi.state")
+local stub = require("luassert.stub")
 
 describe("nvumi.renderer", function()
-  local ctx
+  local ctx, store_output, get_output, clear_ns_spy
+  local real_api
 
   before_each(function()
+    real_api = vim.api
+
     ctx = {
-      buf = api.nvim_create_buf(false, true),
-      ns = api.nvim_create_namespace("nvumi_inline"),
-      opts = { prefix = "!!" },
+      buf = vim.api.nvim_create_buf(false, true),
+      ns = vim.api.nvim_create_namespace("nvumi_inline"),
+      opts = { prefix = "!!", virtual_text = "newline" },
     }
+
+    vim.api.nvim_buf_set_lines(
+      ctx.buf,
+      0,
+      -1,
+      false,
+      { "one for the money", "two for the better green", "3,4-methylenedioxymethamphetamine" }
+    )
+
+    store_output = stub(state, "store_output")
+    get_output = stub(state, "get_output")
+    clear_ns_spy = spy.on(vim.api, "nvim_buf_clear_namespace")
   end)
 
   after_each(function()
-    if api.nvim_buf_is_valid(ctx.buf) then
-      api.nvim_buf_delete(ctx.buf, { force = true })
+    if vim.api.nvim_buf_is_valid(ctx.buf) then
+      vim.api.nvim_buf_delete(ctx.buf, { force = true })
     end
+
+    vim.api = real_api
+    store_output:revert()
+    get_output:revert()
+    clear_ns_spy:revert()
   end)
 
-  it("render_inline should add an extmark with virtual text", function()
+  it("renders inline text with an extmark", function()
     renderer.render_inline(ctx, 0, "inline test")
-    local marks = api.nvim_buf_get_extmarks(ctx.buf, ctx.ns, 0, -1, {})
+    local marks = vim.api.nvim_buf_get_extmarks(ctx.buf, ctx.ns, 0, -1, {})
     assert.is_true(#marks > 0)
   end)
 
-  it("render_newline should add an extmark with virt_lines", function()
+  it("renders newline text with an extmark", function()
     renderer.render_newline(ctx, 0, "newline test")
-    local marks = api.nvim_buf_get_extmarks(ctx.buf, ctx.ns, 0, -1, {})
+    local marks = vim.api.nvim_buf_get_extmarks(ctx.buf, ctx.ns, 0, -1, {})
     assert.is_true(#marks > 0)
+  end)
+
+  it("stores and renders if new result", function()
+    get_output.returns(nil)
+    renderer.render_result(ctx, 1, "result", function() end)
+    assert.spy(clear_ns_spy).was_called(1)
+    assert.stub(store_output).was_called_with(1, "result")
+  end)
+
+  it("not rerender if unchanged result", function()
+    get_output.returns("mmmmcookies")
+
+    local rdr_inln = spy.on(renderer, "render_inline")
+    local rdr_newln = spy.on(renderer, "render_newline")
+
+    renderer.render_result(ctx, 1, "mmmmcookies", function() end)
+    assert.spy(rdr_inln).was_not_called()
+    assert.spy(rdr_newln).was_not_called()
+    rdr_inln:revert()
+    rdr_newln:revert()
+  end)
+
+  it("renders inline if set", function()
+    ctx.opts.virtual_text = "inline"
+    get_output.returns(nil)
+    local render_inline_spy = spy.on(renderer, "render_inline")
+    renderer.render_result(ctx, 2, "catch a throatful", function() end)
+
+    assert.spy(render_inline_spy).was_called(1)
+
+    render_inline_spy:revert()
+  end)
+
+  it("renders newline if set", function()
+    ctx.opts.virtual_text = "newline"
+    get_output.returns(nil)
+
+    local render_newline_spy = spy.on(renderer, "render_newline")
+
+    renderer.render_result(ctx, 2, "fire vocals", function() end)
+    assert.spy(render_newline_spy).was_called(1)
+    render_newline_spy:revert()
   end)
 end)


### PR DESCRIPTION
Very happy with this one - changes to the rendering logic to avoid unnecessary re-rendering - calculations are silky smooth now!

Enhancements to functionality:

* [`lua/nvumi/state.lua`](diffhunk://#diff-9de99030bf31eacf20f1040760ff4cd256ba049bd794b17551ec61a29511d5e3R42-R45): Added a new method `M.get_output` to retrieve stored output for a specific line index.

Improvements to rendering logic:

* [`lua/nvumi/renderer.lua`](diffhunk://#diff-7bb6c2ed06fe4463718467d90751e75f4918d3d76cb0d27c602f67724b15fcd0L27-L40): Modified the `render_result` function to check if the result is the same as the stored output before re-rendering, and added a call to clear the namespace only if the result has changed.

Testing enhancements:

* [`tests/renderer_spec.lua`](diffhunk://#diff-b2b018daf5556ab550225bdd1b5f1fb739a5058c027d1564e5b6f0a7579a1dceL2-R96): Added new tests to verify that `render_result` does not re-render unchanged results, and tests to ensure correct rendering behavior based on the `virtual_text` option.

Removal of redundant code:

* [`lua/nvumi/actions.lua`](diffhunk://#diff-7daf76c1b74c59756c6a70126385dfacea3c2cf8e35a99a411439b5496cccb86L17-L25): Removed unnecessary calls to `vim.api.nvim_buf_clear_namespace` in `run_on_buffer` and `run_on_line` functions.