### PR TITLE
Fix: autocmd triggering on main buffer after quitting quickly

### DIFF
--- a/lua/nvumi/autocmds.lua
+++ b/lua/nvumi/autocmds.lua
@@ -26,7 +26,7 @@ function M.setup()
   })
 
   -- live evaluations
-  local debounced_rol = debounce(200, actions.run_on_line)
+  local debounced_rol = debounce(300, actions.run_on_line)
   vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
     pattern = "*.nvumi",
     callback = function()

--- a/lua/nvumi/autocmds.lua
+++ b/lua/nvumi/autocmds.lua
@@ -18,16 +18,15 @@ function M.setup()
   })
 
   -- evaluate whole buffer on exit insert
-  local debounced_rob = debounce(500, actions.run_on_buffer)
   vim.api.nvim_create_autocmd({ "InsertLeave", "TextChanged" }, {
     pattern = "*.nvumi",
     callback = function()
-      debounced_rob()
+      actions.run_on_buffer()
     end,
   })
 
   -- live evaluations
-  local debounced_rol = debounce(300, actions.run_on_line)
+  local debounced_rol = debounce(200, actions.run_on_line)
   vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
     pattern = "*.nvumi",
     callback = function()


### PR DESCRIPTION
`lua/nvumi/autocmds.lua` 
remove debounce on `actions.run_on_buffer` in the `InsertLeave` and `TextChanged` autocmds.

This command was sometimes causing the Numi evaluations to run on the main buffer behind the scratch window causing visual distortions and needing a nvim reboot.