### PR TITLE
feat: choose date format; additional user cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,24 @@
   }
 }
 ```
+
 You will also need **[numi-cli](https://github.com/nikolaeu/numi)**. Install with:
 
-  ```bash
-  curl -sSL https://s.numi.app/cli | sh
-  ```
+```bash
+curl -sSL https://s.numi.app/cli | sh
+```
 
 or [Homebrew](https://brew.sh/) if on MacOS:
 
-  ```bash
-  brew install nikolaeu/numi/numi-cli
-  ```
+```bash
+brew install nikolaeu/numi/numi-cli
+```
+
+Nvumi does not have a default keybinding to open the buffer out of the box! To create one add something like the below to your config:
+
+```lua
+vim.keymap.set("n", "<leader>on", "<CMD>Nvumi<CR>", { desc = "[O]pen [N]vumi" })
+```
 
 ## Usage
 
@@ -115,7 +122,6 @@ Currently you can configure where you want the virtual text to be displayed, `in
     <img src="https://github.com/user-attachments/assets/f7222430-4cb4-4eb7-a155-477d70dc39ff" alt="Newline Screenshot" />
   </p>
 </details>
-
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,23 @@ Currently you can configure where you want the virtual text to be displayed, `in
   </p>
 </details>
 
+## Extra commands
+
+There are two extra (possibly useless) commands included with Nvumi:
+
+- `NvumiEvalLine`
+- `NvumiEvalBuf`
+
+These will - you guessed it - run Nvumi on ANY line or ANY buffer. Beware that running on a buffer will result in a lot of messy virtual_text (and lots of errors if the text cant be evaluated). But maybe you want to set the `NvumiEvalLine` command to quickly run calculations outside of the scratch buffer.
+
+You can also clear a buffer of the virtual text with `NvumiClear` (or just close it - they wont still be there when you come back).
+
+## The .nvumi filetype
+
+Nvumi was built around a made-up filetype `.nvumi`. This was so that the autocommands used by the plugin under the hood could target a specific filetype without unwanted side effects on other files. It also meant a custom filetype icon could be set for those using nerd fonts.
+
+The fun side-effect/benefit of this, however, is that you can create `.nvumi` files outside of the scratch buffer and they will function exactly the same! You can evaluate to your hearts content in full screen.
+
 ## Contributing
 
 This is my first attempt at a Neovim plugin, so contributions are more than welcome! If you encounter issues or have ideas for improvements, please open an issue or submit a pull request on GitHub.
@@ -134,9 +151,9 @@ A few things I'm thinking about adding as I continue trying to expand my knowled
 - [x] Assigning answers to variables
 - [x] Custom prefixes/suffixes for results (e.g., `=` `→` 🚀 etc).
 - [x] Auto-evaluate expressions as you type without need to press `<CR>`
+- [x] Ability to call numi/evaluate expressions on a line in _any_ buffer on demand
 - [x] Yankable answers!
   - [ ] Stretch: make possible for all evaluations (currently only last output is yankable)
-- [ ] Ability to call numi/evaluate expressions on a line in _any_ buffer on demand
 - [ ] Fine-tuning dates, times, and unit formatting
 - [ ] Additional conversions not currently possible with numi (possibly live prices for currency etc)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
   dependencies = { "folke/snacks.nvim" },
   opts = {
     virtual_text = "newline", -- or "inline"
-    prefix = "= ", -- prefix shown before the virtual text output
+    prefix = " 🚀 ", -- prefix shown before the output
+    date_format = "iso" -- or: "uk", "us", "long"
     keys = {
       run = "<CR>", -- run/refresh calculations
       reset = "R", -- reset buffer
@@ -123,6 +124,17 @@ Currently you can configure where you want the virtual text to be displayed, `in
   </p>
 </details>
 
+## Date formatting
+
+If you care about how your dates are formatted, that is configurable!
+
+| **`date_format`** | **Output**          |
+| ----------------- | ------------------- |
+| `"iso"`           | `2025-02-21`        |
+| `"us"`            | `02/21/2025`        |
+| `"uk"`            | `21/02/2025`        |
+| `"long"`          | `February 21, 2025` |
+
 ## Extra commands
 
 There are two extra (possibly useless) commands included with Nvumi:
@@ -152,9 +164,9 @@ A few things I'm thinking about adding as I continue trying to expand my knowled
 - [x] Custom prefixes/suffixes for results (e.g., `=` `→` 🚀 etc).
 - [x] Auto-evaluate expressions as you type without need to press `<CR>`
 - [x] Ability to call numi/evaluate expressions on a line in _any_ buffer on demand
+- [x] Fine-tuning date format
 - [x] Yankable answers!
   - [ ] Stretch: make possible for all evaluations (currently only last output is yankable)
-- [ ] Fine-tuning dates, times, and unit formatting
 - [ ] Additional conversions not currently possible with numi (possibly live prices for currency etc)
 
 ## License

--- a/lua/nvumi/config.lua
+++ b/lua/nvumi/config.lua
@@ -9,6 +9,7 @@
 ---@class nvumi.Options
 ---@field virtual_text string
 ---@field prefix string
+---@field date_format string
 ---@field keys nvumi.Keys
 
 local M = {}
@@ -16,7 +17,8 @@ local M = {}
 ---@type nvumi.Options
 local defaults = {
   virtual_text = "newline",
-  prefix = "= ",
+  prefix = " 🚀 ",
+  date_format = "iso",
   keys = {
     run = "<CR>",
     reset = "R",

--- a/lua/nvumi/config.lua
+++ b/lua/nvumi/config.lua
@@ -5,6 +5,7 @@
 ---@field run string
 ---@field reset string
 ---@field yank string
+---@field open string
 
 ---@class nvumi.Options
 ---@field virtual_text string
@@ -21,6 +22,7 @@ local defaults = {
     run = "<CR>",
     reset = "R",
     yank = "<leader>y",
+    open = "<leader>on",
   },
 }
 

--- a/lua/nvumi/config.lua
+++ b/lua/nvumi/config.lua
@@ -5,7 +5,6 @@
 ---@field run string
 ---@field reset string
 ---@field yank string
----@field open string
 
 ---@class nvumi.Options
 ---@field virtual_text string
@@ -22,7 +21,6 @@ local defaults = {
     run = "<CR>",
     reset = "R",
     yank = "<leader>y",
-    open = "<leader>on",
   },
 }
 

--- a/lua/nvumi/main.lua
+++ b/lua/nvumi/main.lua
@@ -30,6 +30,18 @@ function M.setup()
     M.open()
   end, {})
 
+  vim.api.nvim_create_user_command("NvumiEvalLine", function()
+    require("nvumi.actions").run_on_line()
+  end, {})
+
+  vim.api.nvim_create_user_command("NvumiEvalBuf", function()
+    require("nvumi.actions").run_on_buffer()
+  end, {})
+
+  vim.api.nvim_create_user_command("NvumiClear", function()
+    require("nvumi.actions").reset_buffer()
+  end, {})
+
   require("nvim-web-devicons").set_icon({ nvumi = { icon = "" } })
 
   autocmds.setup()

--- a/lua/nvumi/main.lua
+++ b/lua/nvumi/main.lua
@@ -30,6 +30,8 @@ function M.setup()
     M.open()
   end, {})
 
+  vim.keymap.set("n", config.options.keys.open, M.open, { desc = "Open Nvumi" })
+
   require("nvim-web-devicons").set_icon({ nvumi = { icon = "" } })
 
   autocmds.setup()

--- a/lua/nvumi/main.lua
+++ b/lua/nvumi/main.lua
@@ -30,8 +30,6 @@ function M.setup()
     M.open()
   end, {})
 
-  vim.keymap.set("n", config.options.keys.open, M.open, { desc = "Open Nvumi" })
-
   require("nvim-web-devicons").set_icon({ nvumi = { icon = "" } })
 
   autocmds.setup()

--- a/lua/nvumi/renderer.lua
+++ b/lua/nvumi/renderer.lua
@@ -1,5 +1,7 @@
 local ns = vim.api.nvim_create_namespace("nvumi_inline")
 local state = require("nvumi.state")
+local units = require("nvumi.units")
+
 local M = {}
 
 ---@param ctx table           context
@@ -33,6 +35,7 @@ function M.render_result(ctx, line_index, result, callback)
 
   state.store_output(line_index, result)
   vim.api.nvim_buf_clear_namespace(ctx.buf, ns, line_index, line_index + 1)
+  result = units.format_date(result)
 
   if ctx.opts.virtual_text == "inline" then
     M.render_inline(ctx, line_index, result)

--- a/lua/nvumi/units.lua
+++ b/lua/nvumi/units.lua
@@ -1,0 +1,41 @@
+local config = require("nvumi.config")
+local M = {}
+
+function M.format_date(result)
+  local format = config.options.date_format
+  local year, month, day = result:match("(%d%d%d%d)-(%d%d)-(%d%d)")
+
+  if not year then
+    return result
+  end
+
+  if format == "iso" then
+    return result
+  end
+
+  if format == "us" then
+    return ("%s/%s/%s"):format(month, day, year)
+  elseif format == "uk" then
+    return ("%s/%s/%s"):format(day, month, year)
+  elseif format == "long" then
+    local months = {
+      "January",
+      "February",
+      "March",
+      "April",
+      "May",
+      "June",
+      "July",
+      "August",
+      "September",
+      "October",
+      "November",
+      "December",
+    }
+    return ("%s %s, %s"):format(months[tonumber(month)], day, year)
+  end
+
+  return result
+end
+
+return M

--- a/tests/units.lua
+++ b/tests/units.lua
@@ -1,0 +1,33 @@
+local assert = require("luassert")
+local units = require("nvumi.units")
+
+describe("nvumi.units.format_date", function()
+  before_each(function()
+    require("nvumi.config").options.date_format = "iso"
+  end)
+
+  it("returns the original result if not a valid date", function()
+    assert.are.same("catch a throatful", units.format_date("catch a throatful"))
+    assert.are.same("42", units.format_date("42"))
+  end)
+
+  it("formats dates in ISO format (YYYY-MM-DD)", function()
+    require("nvumi.config").options.date_format = "iso"
+    assert.are.same("2025-02-21", units.format_date("2025-02-21"))
+  end)
+
+  it("formats dates in US format (MM/DD/YYYY)", function()
+    require("nvumi.config").options.date_format = "us"
+    assert.are.same("02/21/2025", units.format_date("2025-02-21"))
+  end)
+
+  it("formats dates in UK format (DD/MM/YYYY)", function()
+    require("nvumi.config").options.date_format = "uk"
+    assert.are.same("21/02/2025", units.format_date("2025-02-21"))
+  end)
+
+  it("formats dates in long format (Month DD, YYYY)", function()
+    require("nvumi.config").options.date_format = "long"
+    assert.are.same("February 21, 2025", units.format_date("2025-02-21"))
+  end)
+end)


### PR DESCRIPTION
### Features:
* Added support for configurable date formatting with options for "iso", "us", "uk", and "long" formats 
* Introduced three new commands: `NvumiEvalLine`, `NvumiEvalBuf`, and `NvumiClear` to evaluate expressions on a line or buffer (from ANY buffer) and clear virtual text 

### Docs
* Updated `README.md` to include instructions for the new date formatting feature, new commands, and additional configuration details 

### Tests 
Added tests for date formatting