### PR TITLE
chore: type annotations for converter module

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ vim.keymap.set("n", "<leader>on", "<CMD>Nvumi<CR>", { desc = "[O]pen [N]vumi" })
 
 ## 🛠️ Custom conversions
 
-nvumi allows you to define **custom unit conversions** beyond what `numi-cli` provides. This feature was inspired by the [plugins](https://github.com/nikolaeu/numi/tree/master/plugins) that exist for the numi desktop app. These should be compatible with the below format.
+nvumi allows you to define **custom unit conversions** beyond what `numi-cli` provides. This feature was inspired by the [plugins](https://github.com/nikolaeu/numi/tree/master/plugins) that exist for the numi desktop app. These should be compatible with `nvumi`.
 
 💡 **How It Works:**
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ A few things I'm thinking about adding as I continue trying to expand my knowled
 - [x] Fine-tune date format
 - [x] Yankable answers (per line/all at once)
 - [x] **User-defined unit conversions** ✅ _(latest)_
-- [ ] Full syntax highlighting
+- [ ] User-defined maths functions
 
 ## 📜 License
 

--- a/lua/nvumi/converter.lua
+++ b/lua/nvumi/converter.lua
@@ -1,16 +1,22 @@
 local M = {}
 local config = require("nvumi.config")
 
+---@alias Conversion { phrases: string, base_unit: string, ratio: number, format: string? }
+
+---@param s string
+---@return string
 local function trim(s)
   return s:match("^%s*(.-)%s*$")
 end
 
--- trim whitespc
+--- @param unit_str string
+--- @return string
 local function normalize_unit(unit_str)
   return trim(unit_str):lower()
 end
 
--- given a unit str, find  a matching conversion def
+--- @param unit_str string
+---@return Conversion|nil
 local function find_conversion(unit_str)
   local normalized_unit = normalize_unit(unit_str)
 
@@ -25,11 +31,15 @@ local function find_conversion(unit_str)
   return nil
 end
 
--- append the unit's identifier/formatstr to the result
+--- @param value number
+--- @param conversion Conversion
+--- @return string
 local function format_result(value, conversion)
   return conversion and conversion.format and string.format("%s %s", value, conversion.format) or tostring(value)
 end
 
+--- @param expression string
+--- @return string | nil
 local function convert_units(expression)
   expression = trim(expression)
 
@@ -51,6 +61,8 @@ local function convert_units(expression)
   return format_result(result, target_conv)
 end
 
+---@param expression any
+---@return string|nil
 function M.process_custom_conversion(expression)
   return convert_units(expression)
 end


### PR DESCRIPTION
Add type annotations to `numi.converter`.
Tweak readme.