### PR TITLE
fix: yank line output when comments in buffer

### DIFF
--- a/lua/nvumi/state.lua
+++ b/lua/nvumi/state.lua
@@ -72,7 +72,7 @@ end
 
 function M.yank_output_on_line()
   local row, _ = unpack(vim.api.nvim_win_get_cursor(0))
-  local output = M.outputs[row]
+  local output = M.outputs[row - 1]
   if output then
     vim.fn.setreg("+", output)
     vim.notify(("Yanked: %s"):format(output), vim.log.levels.INFO)
@@ -80,4 +80,5 @@ function M.yank_output_on_line()
     vim.notify("No evaluation found on this line", vim.log.levels.ERROR)
   end
 end
+
 return M

--- a/tests/state_spec.lua
+++ b/tests/state_spec.lua
@@ -70,7 +70,7 @@ describe("nvumi.state", function()
     end)
 
     it("yanks output from a specific line", function()
-      state.store_output(1, "im skating the equator")
+      state.store_output(0, "im skating the equator")
       state.yank_output_on_line()
       assert.stub(setreg_stub).was_called_with("+", "im skating the equator")
       assert.stub(notify_stub).was_called_with("Yanked: im skating the equator", vim.log.levels.INFO)


### PR DESCRIPTION
Fixes yanking by line if user has comments in buffer.