### PR TITLE
feat!: improve and expand custom functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ nvumi allows you to define **custom unit conversions** beyond what `numi-cli` pr
 
 ## **🧮 Custom Functions**
 
-nvumi also supports **user-defined mathematical functions**! As with the custom conversions, this was inspired by the community plugins available on the Numi GitHub, such as [this one](https://github.com/nikolaeu/numi/blob/master/plugins/CommunityExtensions/StandardDeviation/StandardDeviation.js) for calculating Standard Deviation.
+nvumi supports **user-defined functions**.
 
-**How It Works:**
+💡 **How It Works:**
 
-- Define **custom functions** in `lua` in your configuration.
-- Functions accept **arguments** (numbers) and return computed results.
-- You can use **aliases** (phrases) to call functions.
+- Define **custom functions** with **aliases**.
+- Functions receive **arguments** (numbers or strings, or nothing) and return computed results.
+- You can include error messages that will surface if something isn't quite right.
 
 ### **Example Configuration**
 
@@ -144,16 +144,25 @@ nvumi also supports **user-defined mathematical functions**! As with the custom 
   opts = {
     custom_functions = {
       {
-        def = { id ="sqr" phrases = "square, sqr" },
+        def = { phrases = "square, sqr" },
         fn = function(args)
-          return { double = args[1].double * args[1].double }
+          if #args < 1 or type(args[1]) ~= "number" then
+            return { error = "square requires a single numeric argument" }
+          end
+          return { result = args[1] * args[1] }
         end,
       },
       {
-        def = { id = "vat", phrases = "vat, tax, nett" }, -- for calculating vat sales tax
+        def = { id = "greet", phrases = "hello, hi" },
         fn = function(args)
-          local vat = args[2] and args[2].double or 20 -- default 20% if no args[2] provided
-          return { double = (args[1].double / (vat + 100)) * 100 } -- apply calculation and return
+          local name = args[1] or "stranger"
+          return { result = "Hello, " .. name .. "!" }
+        end,
+      },
+      {
+        def = { phrases = "coinflip, flip" },
+        fn = function()
+          return { result = (math.random() > 0.5) and "Heads" or "Tails" }
         end,
       },
     },
@@ -163,10 +172,12 @@ nvumi also supports **user-defined mathematical functions**! As with the custom 
 
 ### **Examples**
 
-| Input            | Output |
-| ---------------- | ------ |
-| `square(5)`      | `25`   |
-| `vat(100, 17.5)` | `17.5` |
+| Input           | Output                                               |
+| --------------- | ---------------------------------------------------- |
+| `square(5)`     | `25`                                                 |
+| `square("abc")` | `"Error: square requires a single numeric argument"` |
+| `hello("Joe")`  | `"Hello, Joe!"`                                      |
+| `flip()`        | `Heads` / `Tails`                                    |
 
 ## 🎨 Virtual Text Locations
 

--- a/doc/nvumi.txt
+++ b/doc/nvumi.txt
@@ -23,6 +23,7 @@ calculations. In the scratch buffer:
 
 VARIABLE ASSIGNMENT
 -------------------
+*nvumi-variable-assignment*
 
 nvumi supports **assigning evaluated expressions to variables**. This lets you reuse previously computed values in your calculations.
 
@@ -48,6 +49,7 @@ nvumi supports **assigning evaluated expressions to variables**. This lets you r
 
 CUSTOM CONVERSIONS
 ------------------
+*nvumi-custom-conversions*
 
 nvumi supports **user-defined unit conversions**, allowing you to add your own units.
 
@@ -101,15 +103,14 @@ Example configuration:
 
 CUSTOM FUNCTIONS
 ----------------
-
-nvumi supports **user-defined mathematical functions**, allowing you to extend its capabilities.
-
 *nvumi-custom-functions*
 
-💡 *How It Works*:
-- Define **custom functions** with **aliases** and an associated **function**.
-- Functions receive **arguments** (numbers) and return computed results.
-- You can use **multiple aliases** for the same function.
+nvumi supports **user-defined functions**, allowing you to extend its capabilities.
+
+How It Works:
+- Define **custom functions** with **aliases**.
+- Functions can accept **numbers, strings, or no arguments**.
+- Functions can surface errors by setting an `error` key.
 
 Example configuration:
 
@@ -118,22 +119,36 @@ Example configuration:
     {
       def = { phrases = "square, sqr" },
       fn = function(args)
-        return { double = args[1].double * args[1].double }
+        if #args < 1 or type(args[1]) ~= "number" then
+          return { error = "square requires a single numeric argument" }
+        end
+        return { result = args[1] * args[1] }
       end,
     },
     {
-      def = { phrases = "add" },
+      def = { phrases = "hello, hi" },
       fn = function(args)
-        return { double = args[1].double + args[2].double }
+        local name = args[1] or "stranger"
+        return { result = "Hello, " .. name .. "!" }
+      end,
+    },
+    {
+      def = { phrases = "coinflip, flip" },
+      fn = function()
+	return { result = (math.random() > 0.5) and "Heads" or "Tails" }
       end,
     },
   }
 <
 
-**Usage Examples:**
->lua
+Example output:
+>
+lua
   square(4)  →  16
-  add(2, 3)  →  5
+  hello("Joe")  →  "Hello, Joe!"
+  hello()  →  "Hello, stranger!"
+  square("text")  →  Error: square requires a single numeric argument
+  flip()  →  "Heads" | "Tails"
 <
 
 ---
@@ -192,16 +207,12 @@ nvumi supports the following **configuration options**:
 	{
 	  def = { phrases = "square, sqr" },
 	  fn = function(args)
-	    return { double = args[1].double * args[1].double }
+	    if #args < 1 or type(args[1]) ~= "number" then
+	      return { error = "square requires a single numeric argument" }
+	    end
+	    return { result = args[1] * args[1] }
 	  end,
 	},
-	{
-	  def = { id = "vat", phrases = "vat, tax, nett" }, -- e.g. for calculating sales tax
-	  fn = function(values)
-	    local vat = values[2] and values[2].double or 20 -- default 20% or use second arg as p/c amount
-	    return { double = (values[1].double / (vat + 100)) * 100 } -- apply calculation and return
-	  end,
-	}
       }
     }
   }

--- a/lua/nvumi/converter.lua
+++ b/lua/nvumi/converter.lua
@@ -18,11 +18,11 @@ end
 --- @param unit_str string
 ---@return Conversion|nil
 local function find_conversion(unit_str)
-  local normalized_unit = normalize_unit(unit_str)
+  local custom_conversions = config.options.custom_conversions or {}
 
-  for _, conversion in ipairs(config.options.custom_conversions or {}) do
+  for _, conversion in ipairs(custom_conversions) do
     for phrase in conversion.phrases:gmatch("[^,]+") do
-      if normalize_unit(phrase) == normalized_unit then
+      if normalize_unit(phrase) == normalize_unit(unit_str) then
         return conversion
       end
     end
@@ -37,23 +37,24 @@ end
 local function format_result(value, conversion)
   return conversion and conversion.format and string.format("%s %s", value, conversion.format) or tostring(value)
 end
+local function extract_conversion_val_and_units(expression)
+  local value_str, source_unit, target_unit = trim(expression):match("^(%d+%.?%d*)%s+(.+)%s+in%s+(.+)%s*$")
+  return tonumber(value_str), source_unit, target_unit
+end
 
 --- @param expression string
 --- @return string | nil
 local function convert_units(expression)
-  expression = trim(expression)
+  local value, source_unit, target_unit = extract_conversion_val_and_units(expression)
 
-  local value_str, source_unit, target_unit = expression:match("^(%d+%.?%d*)%s+(.+)%s+in%s+(.+)%s*$")
-  if not value_str then
+  if not value or not source_unit or not target_unit then
     return nil
   end
 
-  local value = tonumber(value_str)
-  local source_conv = find_conversion(source_unit)
-  local target_conv = find_conversion(target_unit)
+  local source_conv, target_conv = find_conversion(source_unit), find_conversion(target_unit)
 
   -- ensure both units exist w/ same base unit
-  if not (source_conv and target_conv) or source_conv.base_unit ~= target_conv.base_unit then
+  if not (source_conv and target_conv and source_conv.base_unit == target_conv.base_unit) then
     return nil
   end
 

--- a/lua/nvumi/evaluator.lua
+++ b/lua/nvumi/evaluator.lua
@@ -23,19 +23,21 @@ end
 --- @return table|nil
 local function parse_args(args_str)
   if not args_str or args_str:match("^%s*$") then
-    return nil
+    return {}
   end
 
   local args = {}
+
   for arg in args_str:gmatch("[^,]+") do
     local num = tonumber(arg:match("^%s*(.-)%s*$"))
-    if not num then
-      return nil
+    if num then
+      table.insert(args, num)
+    else
+      table.insert(args, arg)
     end
-    table.insert(args, { double = num })
   end
 
-  return #args > 0 and args or nil
+  return args
 end
 
 --- @param expression string
@@ -52,12 +54,18 @@ function M.evaluate_function(expression)
   end
 
   local args = parse_args(args_str)
-  if not args then
+
+  if args == nil then
     return nil
   end
 
   local result = target_fn(args)
-  return result and tostring(result.double) or nil
+
+  if result.error then
+    return "Error: " .. result.error
+  elseif result.result then
+    return tostring(result.result)
+  end
 end
 
 return M

--- a/lua/nvumi/evaluator.lua
+++ b/lua/nvumi/evaluator.lua
@@ -2,41 +2,34 @@ local config = require("nvumi.config")
 
 local M = {}
 
+--- @param str string
+--- @return string
+local function normalize(str)
+  return str:match("^%s*(.-)%s*$"):lower()
+end
+
 --- @param fn_name string
 --- @return function|nil
 local function get_target_fn(fn_name)
   local custom_functions = config.options.custom_functions or {}
 
   for _, f in ipairs(custom_functions) do
-    local phrases = f.def and f.def.phrases or ""
-    for phrase in phrases:gmatch("[^,]+") do
-      if phrase:match("^%s*(.-)%s*$"):lower() == fn_name:lower() then
+    for phrase in (f.def and f.def.phrases or ""):gmatch("[^,]+") do
+      if normalize(phrase) == normalize(fn_name) then
         return f.fn
       end
     end
   end
-
-  return nil
 end
 
 --- @param args_str string
---- @return table|nil
+--- @return table
 local function parse_args(args_str)
-  if not args_str or args_str:match("^%s*$") then
-    return {}
-  end
-
   local args = {}
-
-  for arg in args_str:gmatch("[^,]+") do
-    local num = tonumber(arg:match("^%s*(.-)%s*$"))
-    if num then
-      table.insert(args, num)
-    else
-      table.insert(args, arg)
-    end
+  for arg in (args_str or ""):gmatch("[^,]+") do
+    local value = tonumber(normalize(arg)) or normalize(arg)
+    table.insert(args, value)
   end
-
   return args
 end
 
@@ -44,28 +37,13 @@ end
 --- @return string|nil
 function M.evaluate_function(expression)
   local fn_name, args_str = expression:match("^%s*(%a+)%s*%((.-)%)%s*$")
-  if not fn_name then
-    return nil
-  end
-
-  local target_fn = get_target_fn(fn_name)
+  local target_fn = fn_name and get_target_fn(fn_name)
   if not target_fn then
     return nil
   end
 
-  local args = parse_args(args_str)
-
-  if args == nil then
-    return nil
-  end
-
-  local result = target_fn(args)
-
-  if result.error then
-    return "Error: " .. result.error
-  elseif result.result then
-    return tostring(result.result)
-  end
+  local result = target_fn(parse_args(args_str))
+  return result.error and "Error: " .. result.error or tostring(result.result)
 end
 
 return M

--- a/tests/evaluator_spec.lua
+++ b/tests/evaluator_spec.lua
@@ -52,4 +52,8 @@ describe("nvumi.evaluator", function()
     local result = evaluator.evaluate_function("  square (   6   )  ")
     assert.are.same("36", result)
   end)
+
+  it("return nil for bad input", function()
+    assert.is_nil(evaluator.evaluate_function("square"))
+  end)
 end)

--- a/tests/evaluator_spec.lua
+++ b/tests/evaluator_spec.lua
@@ -6,15 +6,18 @@ describe("nvumi.evaluator", function()
   before_each(function()
     config.options.custom_functions = {
       {
-        def = { phrases = "square, sqr" },
+        def = { phrases = "add" },
         fn = function(args)
-          return { double = args[1].double * args[1].double }
+          return { result = args[1] + args[2] }
         end,
       },
       {
-        def = { phrases = "add" },
+        def = { phrases = "square, sqr" },
         fn = function(args)
-          return { double = args[1].double + args[2].double }
+          if type(args[1]) ~= "number" then
+            return { error = "should be a num bro!" }
+          end
+          return { result = args[1] * args[1] }
         end,
       },
     }
@@ -35,12 +38,12 @@ describe("nvumi.evaluator", function()
     assert.is_nil(result)
   end)
 
-  it("return nil for bad args", function()
+  it("returns error msgs", function()
     local result = evaluator.evaluate_function("square(abc)")
-    assert.is_nil(result)
+    assert.are.same("Error: should be a num bro!", result)
   end)
 
-  it("fn names are not case sensitvie", function()
+  it("fn names are not case-sensitive", function()
     local result = evaluator.evaluate_function("SQR(5)")
     assert.are.same("25", result)
   end)
@@ -48,11 +51,5 @@ describe("nvumi.evaluator", function()
   it("ignores extra spaces", function()
     local result = evaluator.evaluate_function("  square (   6   )  ")
     assert.are.same("36", result)
-  end)
-
-  it("return nil for bad input", function()
-    assert.is_nil(evaluator.evaluate_function("square"))
-    assert.is_nil(evaluator.evaluate_function("square()"))
-    assert.is_nil(evaluator.evaluate_function("square(,)"))
   end)
 end)


### PR DESCRIPTION
This PR enhances custom function support beyond mathematical functions, allowing for string or nil args, and adding error handling/surfacing.

This is a breaking change for existing custom functions. args are no longer stored in a table of the format:\
`{ double = arg }`
they are now in a list of args e.g: 
`{ arg, arg2, ... }`

The return for custom functions has also been changed since we are no longer solely returning numerical values. Instead of returning:
`{ double = xyz }` 
it should now be:
`{ result = xyz }`

Error handling has also been added. 

It is recommended to make the functions safely handle errors for easier/nicer feedback than vim runtime errors.

Example below:
```lua
{
  opts = {
    custom_functions = {
      {
        def = { phrases = "square, sqr" },
        fn = function(args)
          if #args < 1 or type(args[1]) ~= "number" then
            return { error = "square requires a single numeric argument" }
          end
          return { result = args[1] * args[1] }
        end,
      },
    }
  }
}
```