### PR TITLE
feat: inline expressions within {} braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ nvumi supports **user-defined functions**.
 | `hello("Joe")`  | `"Hello, Joe!"`                                      |
 | `flip()`        | `Heads` / `Tails`                                    |
 
+### ** 🤹 Inline `{}` Evaluations**
+
+nvumi now supports **inline evaluations** using `{}` curly braces. Expressions inside `{}` are **evaluated first**, and the result is **inserted into the full line before processing**. This in particular
+
+This isn't always necessary, for example when assigning variables or doing normal math expressions, numi should be sufficient, but for custom functions/custom conversions this allows greater interoperability between expressions and your custom setup.
+
+#### **💡 Example Usage**
+
+| Input                 | Step 1 - Evaluate `{}` | Step 2 - Final Output |
+| --------------------- | ---------------------- | --------------------- |
+| `log({10*10}, {5+5})` | `log(100, 10)`         | `2`                   |
+| `{10+20} mph in kmh`  | `30 mph in kmh`        | `48.28032 km/h`       |
+
 ## 🎨 Virtual Text Locations
 
 nvumi supports two virtual text modes:

--- a/doc/nvumi.txt
+++ b/doc/nvumi.txt
@@ -20,7 +20,6 @@ calculations. In the scratch buffer:
   - Press `<leader>y` in normal mode to **yank the evaluation** of the current line.
   - Press `<leader>Y` in normal mode to **yank all evaluations**.
 
-
 VARIABLE ASSIGNMENT
 -------------------
 *nvumi-variable-assignment*
@@ -152,6 +151,28 @@ lua
 <
 
 ---
+
+INLINE `{}` EVALUATIONS
+------------------------
+*nvumi-inline-evaluations*
+
+nvumi supports inline evaluations using `{}` curly braces. Any expression inside
+`{}` is evaluated first, and the result is inserted into the full line before
+processing.
+
+in a lot of instances this is not necessary, however for example if you wish
+to run a function on an expression in one line then it would be required, as
+the arg parsing of the custom functions evaluator would trip up if passsing
+the expressions in directly like `factorial(2*3).`
+
+**Example Usage:**
+
+    {10+20} mph in kmh    →   30 mph in kmh  →  48.28032 km/h
+    log({10*10}, {5+5})   →   log(100, 10)   →  2
+
+This allows for seamless integration between math calculations, functions,
+and unit conversions within a single line.
+
 
 CONFIGURATION
 -------------

--- a/lua/nvumi/evaluator.lua
+++ b/lua/nvumi/evaluator.lua
@@ -35,10 +35,16 @@ end
 --- @return string|nil
 function M.evaluate_function(expression)
   local fn_name, args_str = expression:match("^%s*(%a+)%s*%((.-)%)%s*$")
-  local target_fn = fn_name and get_target_fn(fn_name)
+  if not fn_name then return nil end
+
+  local target_fn = get_target_fn(fn_name)
   if not target_fn then return nil end
 
-  local result = target_fn(parse_args(args_str))
+  local success, result = pcall(function()
+    return target_fn(parse_args(args_str or ""))
+  end)
+
+  if not success then return "??" end
   return result.error and "Error: " .. result.error or tostring(result.result)
 end
 

--- a/lua/nvumi/runner.lua
+++ b/lua/nvumi/runner.lua
@@ -18,4 +18,16 @@ function M.run_numi(expr, callback)
   })
 end
 
+---@param expr string
+---@return string
+function M.run_numi_sync(expr)
+  if vim.fn.executable("numi-cli") == 0 then
+    vim.notify("Error: `numi-cli` is not installed or not in PATH.\n" .. "Type `:help Nvumi` for more.", vim.log.levels.ERROR)
+    return ""
+  end
+
+  local output = (vim.fn.system({ "numi-cli", expr }) or ""):gsub("\n", "")
+  return output
+end
+
 return M

--- a/tests/processor_spec.lua
+++ b/tests/processor_spec.lua
@@ -60,4 +60,24 @@ describe("nvumi.processor", function()
     assert.are.same("madvillainy", output)
     assert.spy(mock_run_numi).was_called(1)
   end)
+
+  it("evaluates {} expressions before full line processing", function()
+    local output
+    processor.process_line(ctx, "{10+20}mph in kmh", 1, function()
+      output = state.get_last_output()
+    end)
+
+    assert.are.same("madvillainy", output) -- Mocked numi output
+    assert.spy(mock_run_numi).was_called(1)
+  end)
+
+  it("handles empty {} gracefully", function()
+    local output
+    processor.process_line(ctx, "{} + 5", 1, function()
+      output = state.get_last_output()
+    end)
+
+    assert.are.same("madvillainy", output) -- Expected to not crash
+    assert.spy(mock_run_numi).was_called(1)
+  end)
 end)


### PR DESCRIPTION
### ** 🤹 Inline `{}` Evaluations**

nvumi now supports **inline evaluations** using `{}` curly braces. Expressions inside `{}` are **evaluated first**, and the result is **inserted into the full line before processing**. This in particular

This isn't always necessary, for example when assigning variables or doing normal math expressions, numi should be sufficient, but for custom functions/custom conversions this allows greater interoperability between expressions and your custom setup.

#### **💡 Example Usage**

| Input                 | Step 1 - Evaluate `{}` | Step 2 - Final Output |
| --------------------- | ---------------------- | --------------------- |
| `log({10*10}, {5+5})` | `log(100, 10)`         | `2`                   |
| `{10+20} mph in kmh`  | `30 mph in kmh`        | `48.28032 km/h`       |
