### PR TITLE
feat!: remove snacks dependency, 2026 refactor and refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ opts = {
 
 | Command         | Description                                                   |
 | --------------- | ------------------------------------------------------------- |
-| `NvumiEvalLine` | Run nvumi on **any line** in any buffer.                      |
-| `NvumiEvalBuf`  | Run nvumi on the **entire buffer** anywhere. Can be messy!    |
-| `NvumiClear`    | **Clears** the buffer's virtual text.                         |
+| `NvumiEvalLine` | Run nvumi on **any line** in any buffer |
+| `NvumiEvalBuf`  | Run nvumi on the **entire buffer** anywhere (this will probably be messy...)    |
+| `NvumiClear`    | Clears the buffer's virtual text                         |
 
 ## `.nvumi` filetype
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://github.com/user-attachments/assets/c0d0fd19-7acf-49db-96d2-0da9eda3b088" alt="Gif" />
 </p>
 
-## 🔧 Installation
+## Installation
 
 ### Using Lazy.nvim
 
@@ -16,7 +16,7 @@
   dependencies = { "folke/snacks.nvim" },
   opts = {
     virtual_text = "newline", -- or "inline"
-    prefix = " 🚀 ", -- prefix shown before the output
+    prefix = " = ", -- prefix shown before the output
     date_format = "iso", -- or: "uk", "us", "long"
     keys = {
       run = "<CR>", -- run/refresh calculations
@@ -35,39 +35,37 @@
 
 You will also need **[numi-cli](https://github.com/nikolaeu/numi)**.
 
-#### 🖥 MacOS
+**MacOS**
 
 ```sh
 brew install nikolaeu/numi/numi-cli
 ```
 
-#### 📦 Linux & Windows
+**Linux & Windows**
 
 ```sh
 curl -sSL https://s.numi.app/cli | sh
 ```
 
-### Keybinding to open `nvumi`
+### Keybinding to open nvumi
 
 nvumi does not have a default keybinding to open the scratch buffer. You can set one:
 
 ```lua
-vim.keymap.set("n", "<leader>on", "<CMD>Nvumi<CR>", { desc = "[O]pen [N]vumi" })
+vim.keymap.set("n", "<leader>on", "<CMD>Nvumi<CR>", { desc = "Open nvumi" })
 ```
 
-## 🚀 Usage
+## Usage
 
 1. Run `:Nvumi` to open a scratch buffer.
 2. Type a natural language expression (`20 inches in cm`).
 3. The result appears **inline** or on a **new line**, based on your settings.
-4. Press `<CR>` to **refresh** calculations if you need.
-5. Use `<leader>y` to **yank the current result** (or `<leader>Y` for all results).
+4. Press `<CR>` to refresh calculations.
+5. Use `<leader>y` to yank the current result (or `<leader>Y` for all results).
 
-## 📌 Variable Assignment
+## Variable Assignment
 
-nvumi supports **variables**, allowing you to store values and reuse them later. Variable names must start with a letter or underscore, followed by letters, numbers, or underscores.
-
-### **Example**
+nvumi supports variables — store values and reuse them in subsequent expressions. Variable names must start with a letter or underscore, followed by letters, numbers, or underscores.
 
 ```text
 x = 20 inches in cm
@@ -79,23 +77,17 @@ y meters in kilometers
 
 - `x` stores the result of `20 inches in cm`
 - `y` holds `5000`
-- You can use them in expressions like `x * y` (which equals `254000.00 cm`, btw)
+- Expressions like `x * y` use the stored values
 
-### **Resetting Variables**
+Pressing `R` to reset the buffer also clears all stored variables.
 
-Pressing `<R>` to reset the buffer will also **clear all stored variables**.
+## Custom Conversions
 
-## 🔄 Custom conversions
+nvumi supports user-defined unit conversions beyond what `numi-cli` provides. This was inspired by the [plugins](https://github.com/nikolaeu/numi/tree/master/plugins) that exist for the numi desktop app — those should be compatible with nvumi.
 
-nvumi allows you to define **custom unit conversions** beyond what `numi-cli` provides. This feature was inspired by the [plugins](https://github.com/nikolaeu/numi/tree/master/plugins) that exist for the numi desktop app. These should be compatible with `nvumi`.
-
-💡 **How It Works:**
-
-- You can define **custom units** with **aliases**, a **base unit group**, and a **conversion ratio**.
-- Custom conversions **must share the same `base_unit`** (e.g., `"speed"`, `"volume"`).
-- When converting, **ratios are relative to the base unit**.
-
-### **Example Configuration**
+- Define custom units with **aliases**, a **base unit group**, and a **conversion ratio**.
+- Custom conversions must share the same `base_unit` (e.g., `"speed"`, `"volume"`).
+- Ratios are relative to the base unit.
 
 ```lua
 {
@@ -120,24 +112,14 @@ nvumi allows you to define **custom unit conversions** beyond what `numi-cli` pr
 }
 ```
 
-### **Examples**
-
 | Input                  | Output        |
 | ---------------------- | ------------- |
 | `10 gallons in liters` | `37.8541 L`   |
 | `5 kmh in mph`         | `3.10686 mph` |
 
-## **🧮 Custom Functions**
+## Custom Functions
 
-nvumi supports **user-defined functions**.
-
-💡 **How It Works:**
-
-- Define **custom functions** with **aliases**.
-- Functions receive **arguments** (numbers or strings, or nothing) and return computed results.
-- You can include error messages that will surface if something isn't quite right.
-
-### **Example Configuration**
+nvumi supports user-defined functions with aliases. Functions receive arguments (numbers or strings, or nothing) and return computed results. You can include error messages that will surface if something goes wrong.
 
 ```lua
 {
@@ -170,8 +152,6 @@ nvumi supports **user-defined functions**.
 }
 ```
 
-### **Examples**
-
 | Input           | Output                                               |
 | --------------- | ---------------------------------------------------- |
 | `square(5)`     | `25`                                                 |
@@ -179,20 +159,16 @@ nvumi supports **user-defined functions**.
 | `hello("Joe")`  | `"Hello, Joe!"`                                      |
 | `flip()`        | `Heads` / `Tails`                                    |
 
-### ** 🤹 Inline `{}` Evaluations**
+## Inline `{}` Evaluations
 
-nvumi now supports **inline evaluations** using `{}` curly braces. Expressions inside `{}` are **evaluated first**, and the result is **inserted into the full line before processing**. This in particular
-
-This isn't always necessary, for example when assigning variables or doing normal math expressions, numi should be sufficient, but for custom functions/custom conversions this allows greater interoperability between expressions and your custom setup.
-
-#### **💡 Example Usage**
+Expressions inside `{}` are evaluated first and the result is substituted into the full line before processing. This is particularly useful with custom functions or conversions, where passing a raw expression as an argument would confuse the parser.
 
 | Input                 | Step 1 - Evaluate `{}` | Step 2 - Final Output |
 | --------------------- | ---------------------- | --------------------- |
 | `log({10*10}, {5+5})` | `log(100, 10)`         | `2`                   |
 | `{10+20} mph in kmh`  | `30 mph in kmh`        | `48.28032 km/h`       |
 
-## 🎨 Virtual Text Locations
+## Virtual Text Modes
 
 nvumi supports two virtual text modes:
 
@@ -213,7 +189,7 @@ nvumi supports two virtual text modes:
   </p>
 </details>
 
-## 📅 Date Formatting
+## Date Formatting
 
 | **Format** | **Example Output**  |
 | ---------- | ------------------- |
@@ -222,60 +198,37 @@ nvumi supports two virtual text modes:
 | `"uk"`     | `21/02/2025`        |
 | `"long"`   | `February 21, 2025` |
 
-Set this in your config:
-
 ```lua
 opts = {
   date_format = "iso", -- or: "uk", "us", "long"
 }
 ```
 
-## Extra commands
-
-There are three extra (possibly useless) commands included with nvumi:
+## Extra Commands
 
 | Command         | Description                                                   |
 | --------------- | ------------------------------------------------------------- |
 | `NvumiEvalLine` | Run nvumi on **any line** in any buffer.                      |
-| `NvumiEvalBuf`  | Run nvumi on the **entire buffer** anywhere. ⚠️ Can be messy! |
+| `NvumiEvalBuf`  | Run nvumi on the **entire buffer** anywhere. Can be messy!    |
 | `NvumiClear`    | **Clears** the buffer's virtual text.                         |
 
-## 📁 `.nvumi` filetype
+## `.nvumi` filetype
 
-nvumi was built around a made-up filetype `.nvumi`. This was so that the autocommands used by the plugin under the hood would not start trying to evaluate random files.
+nvumi uses a custom filetype `.nvumi` so that the autocommands don't trigger on arbitrary buffers. As a side effect, you can create and save `.nvumi` files outside of the scratch buffer and they work exactly the same.
 
-The fun side-effect of this, however, is that you can create/save `.nvumi` files outside of the scratch buffer and they will function exactly the same!
+## Wiki
 
-## 📚 Wiki
-
-This README hopefully had a good enough outline of current features and examples to get you started, however there is also a [Wiki](https://github.com/josephburgess/nvumi/wiki) being expanded with more in-depth info.
-
-In particular it includes a [Recipes](https://github.com/josephburgess/nvumi/wiki/Recipes) page with some example custom conversions/functions.
+There is a [Wiki](https://github.com/josephburgess/nvumi/wiki) with more detail, including a [Recipes](https://github.com/josephburgess/nvumi/wiki/Recipes) page with example custom conversions and functions.
 
 ## Contributing
 
-This is my first attempt at a Neovim plugin, so contributions are more than welcome! If you encounter issues or have ideas for improvements, please open an issue or submit a pull request on GitHub.
+This is my first attempt at a Neovim plugin, so contributions are more than welcome. If you encounter issues or have ideas for improvements, please open an issue or submit a pull request on GitHub.
 
-## 💡 Roadmap & Planned Features
-
-A few things I'm thinking about adding as I continue trying to expand my knowledge of `lua` and plugin development:
-
-- [x] Variable Assignment
-- [x] Custom prefixes/suffixes (`=`, `→`, `🚀`)
-- [x] Auto-evaluate expressions while typing
-- [x] Run on any buffer outside scratch
-- [x] Custom date format
-- [x] Yankable answers (per line/all at once)
-- [x] **User-defined unit conversions**
-- [x] User-defined maths functions ✅ _(latest)_
-
-## 📜 License
+## License
 
 MIT License. See [LICENSE](LICENSE) for details.
 
-## 🙌 Acknowledgements
+## Acknowledgements
 
-- **[Snacks.nvim](https://github.com/folke/snacks.nvim):**
-  Thanks @folke for the incredible plugin. The `lua` code runner built into the Scratch buffer inspired this idea in the first place! Thanks also also for your super-human contributions to the community in general.
-- **[numi](https://github.com/nikolaeu/numi):**
-  Thanks for providing an amazing natural language calculator.
+- **[Snacks.nvim](https://github.com/folke/snacks.nvim):** The Lua code runner built into the Scratch buffer inspired this idea. Thanks @folke.
+- **[numi](https://github.com/nikolaeu/numi):** The natural language calculator this plugin wraps.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nvumi
 
-**nvumi** is a Neovim plugin that integrates the [numi](https://github.com/nikolaeu/numi) natural language calculator with [Snacks.nvim's](https://github.com/folke/snacks.nvim/blob/main/docs/scratch.md) scratch buffer. It lets you construct natural language expressions and see the results evaluated inline as you type.
+**nvumi** is a Neovim plugin that integrates the [numi](https://github.com/nikolaeu/numi) natural language calculator with a scratch buffer. It lets you construct natural language expressions and see the results evaluated inline as you type.
 
 <p align="center">
   <img src="https://github.com/user-attachments/assets/c0d0fd19-7acf-49db-96d2-0da9eda3b088" alt="Gif" />
@@ -64,7 +64,7 @@ vim.keymap.set("n", "<leader>on", "<CMD>Nvumi<CR>", { desc = "Open nvumi" })
 
 ## Variable Assignment
 
-nvumi supports variables — store values and reuse them in subsequent expressions. Variable names must start with a letter or underscore, followed by letters, numbers, or underscores.
+nvumi supports variables for storing values and reusing them in subsequent expressions. Variable names must start with a letter or underscore, followed by letters, numbers, or underscores.
 
 ```text
 x = 20 inches in cm
@@ -82,11 +82,11 @@ Pressing `R` to reset the buffer also clears all stored variables.
 
 ## Custom Conversions
 
-nvumi supports user-defined unit conversions beyond what `numi-cli` provides. This was inspired by the [plugins](https://github.com/nikolaeu/numi/tree/master/plugins) that exist for the numi desktop app — those should be compatible with nvumi.
+nvumi supports user-defined unit conversions beyond what `numi-cli` provides. This was inspired by the [plugins](https://github.com/nikolaeu/numi/tree/master/plugins) that exist for the numi desktop app (those should be compatible with nvumi too).
 
-- Define custom units with **aliases**, a **base unit group**, and a **conversion ratio**.
-- Custom conversions must share the same `base_unit` (e.g., `"speed"`, `"volume"`).
-- Ratios are relative to the base unit.
+- Define custom units with **aliases**, a **base unit group**, and a **conversion ratio**
+- Custom conversions must share the same `base_unit` (e.g., `"speed"`, `"volume"`)
+- Ratios are relative to the base unit
 
 ```lua
 {
@@ -229,5 +229,5 @@ MIT License. See [LICENSE](LICENSE) for details.
 
 ## Acknowledgements
 
-- **[Snacks.nvim](https://github.com/folke/snacks.nvim):** The Lua code runner built into the Scratch buffer inspired this idea. Thanks @folke.
 - **[numi](https://github.com/nikolaeu/numi):** The natural language calculator this plugin wraps.
+- **[Snacks.nvim](https://github.com/folke/snacks.nvim):** The Lua runner built into snacks.Scratch inspired this idea. Snacks is no longer a dependency but still worth a shout out. Thanks @folke.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 ```lua
 {
   "josephburgess/nvumi",
-  dependencies = { "folke/snacks.nvim" },
   opts = {
     virtual_text = "newline", -- or "inline"
     prefix = " = ", -- prefix shown before the output

--- a/doc/nvumi.txt
+++ b/doc/nvumi.txt
@@ -52,10 +52,9 @@ CUSTOM CONVERSIONS
 
 nvumi supports **user-defined unit conversions**, allowing you to add your own units.
 
-💡 **How It Works**:
-- Define **custom units** with **aliases**, a **base unit group**, and a **conversion ratio**.
-- Custom conversions **must share the same base unit** (e.g., `"speed"`, `"volume"`).
-- When converting, **ratios are relative to the base unit**.
+- Define custom units with aliases, a base unit group, and a conversion ratio.
+- Custom conversions must share the same `base_unit` (e.g., `"speed"`, `"volume"`).
+- Ratios are relative to the base unit.
 
 Example configuration:
 
@@ -134,7 +133,7 @@ Example configuration:
     {
       def = { phrases = "coinflip, flip" },
       fn = function()
-	return { result = (math.random() > 0.5) and "Heads" or "Tails" }
+        return { result = (math.random() > 0.5) and "Heads" or "Tails" }
       end,
     },
   }
@@ -160,10 +159,9 @@ nvumi supports inline evaluations using `{}` curly braces. Any expression inside
 `{}` is evaluated first, and the result is inserted into the full line before
 processing.
 
-in a lot of instances this is not necessary, however for example if you wish
-to run a function on an expression in one line then it would be required, as
-the arg parsing of the custom functions evaluator would trip up if passsing
-the expressions in directly like `factorial(2*3).`
+This is often not necessary, but is useful when passing an expression as a
+function argument — the custom function parser would otherwise treat the raw
+expression as a string rather than evaluating it first.
 
 **Example Usage:**
 
@@ -193,7 +191,7 @@ nvumi supports the following **configuration options**:
   keys.yank_all = "<leader>Y"  -- Yanks all evaluations.
 <
 
-### **Example Configuration in Lazy.nvim**
+Example configuration (Lazy.nvim):
 >lua
   {
     "josephburgess/nvumi",
@@ -225,15 +223,15 @@ nvumi supports the following **configuration options**:
         },
       },
       custom_functions = {
-	{
-	  def = { phrases = "square, sqr" },
-	  fn = function(args)
-	    if #args < 1 or type(args[1]) ~= "number" then
-	      return { error = "square requires a single numeric argument" }
-	    end
-	    return { result = args[1] * args[1] }
-	  end,
-	},
+        {
+          def = { phrases = "square, sqr" },
+          fn = function(args)
+            if #args < 1 or type(args[1]) ~= "number" then
+              return { error = "square requires a single numeric argument" }
+            end
+            return { result = args[1] * args[1] }
+          end,
+        },
       }
     }
   }

--- a/doc/nvumi.txt
+++ b/doc/nvumi.txt
@@ -251,8 +251,6 @@ REQUIREMENTS
 >bash
   brew install nikolaeu/numi/numi-cli
 <
-- **snacks.nvim:** Used to create the scratch buffer.
-
 ---
 
 EXAMPLES

--- a/lua/nvumi/autocmds.lua
+++ b/lua/nvumi/autocmds.lua
@@ -6,36 +6,39 @@ local M = {}
 local cmd_group = vim.api.nvim_create_augroup("NvumiAutocmds", { clear = true })
 
 function M.setup()
-  -- setup comments/syntax highlighting
   vim.api.nvim_create_autocmd("FileType", {
     group = cmd_group,
     pattern = "nvumi",
-    callback = function()
-      vim.bo.commentstring = "-- %s"
-      vim.cmd("set syntax=nvumi")
+    callback = function(ev)
+      vim.bo[ev.buf].commentstring = "-- %s"
+      vim.cmd("setlocal syntax=nvumi")
       vim.cmd([[
         syntax clear Comment
         syntax match Comment /^\s*--.*/
       ]])
-    end,
-  })
 
-  -- evaluate whole buffer on exit insert
-  vim.api.nvim_create_autocmd({ "InsertLeave", "TextChanged" }, {
-    group = cmd_group,
-    pattern = "*.nvumi",
-    callback = function()
-      actions.run_on_buffer()
-    end,
-  })
+      local buf_group = vim.api.nvim_create_augroup("NvumiBuffer_" .. ev.buf, { clear = true })
 
-  -- live evaluations
-  local debounced_rol = debounce(300, actions.run_on_line)
-  vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
-    group = cmd_group,
-    pattern = "*.nvumi",
-    callback = function()
-      debounced_rol()
+      vim.api.nvim_create_autocmd("InsertLeave", {
+        group = buf_group,
+        buffer = ev.buf,
+        callback = actions.run_on_buffer,
+      })
+
+      local debounced_rob = debounce(300, actions.run_on_buffer)
+      local debounced_rol = debounce(300, actions.run_on_line)
+
+      vim.api.nvim_create_autocmd("TextChanged", {
+        group = buf_group,
+        buffer = ev.buf,
+        callback = debounced_rob,
+      })
+
+      vim.api.nvim_create_autocmd("TextChangedI", {
+        group = buf_group,
+        buffer = ev.buf,
+        callback = debounced_rol,
+      })
     end,
   })
 end

--- a/lua/nvumi/debounce.lua
+++ b/lua/nvumi/debounce.lua
@@ -4,7 +4,7 @@ local M = {}
 --- @param fn function: function to debounce
 --- @return function:   debounced function
 function M.debounce(ms, fn)
-  local timer = vim.loop.new_timer()
+  local timer = vim.uv.new_timer()
   return function(...)
     local args = { ... }
     timer:stop()

--- a/lua/nvumi/main.lua
+++ b/lua/nvumi/main.lua
@@ -1,35 +1,14 @@
-local actions = require("nvumi.actions")
 local autocmds = require("nvumi.autocmds")
-local config = require("nvumi.config")
-local state = require("nvumi.state")
 local M = {}
 
 ---@return nil
 function M.open()
-  local opts = config.options
-  ---@diagnostic disable-next-line: missing-fields
-  require("snacks.scratch").open({
-    name = "Nvumi",
-    ft = "nvumi",
-    icon = "",
-    win_by_ft = {
-      nvumi = {
-        keys = {
-          ["source"] = { opts.keys.run, actions.run_on_buffer, mode = { "n", "x" }, desc = "Run" },
-          ["reset"] = { opts.keys.reset, actions.reset_buffer, mode = "n", desc = "Reset" },
-          ["yank"] = { opts.keys.yank, state.yank_output_on_line, mode = "n", desc = "Yank Line" },
-          ["yank_all"] = { opts.keys.yank_all, state.yank_all_outputs, mode = "n", desc = "Yank All" },
-        },
-      },
-    },
-  })
+  require("nvumi.scratch").open()
 end
 
 ---@return nil
 function M.setup()
-  vim.api.nvim_create_user_command("Nvumi", function()
-    M.open()
-  end, {})
+  vim.api.nvim_create_user_command("Nvumi", M.open, {})
 
   vim.api.nvim_create_user_command("NvumiEvalLine", function()
     require("nvumi.actions").run_on_line()
@@ -44,7 +23,7 @@ function M.setup()
   end, {})
 
   local ok, devicons = pcall(require, "nvim-web-devicons")
-  if ok then devicons.set_icon({ nvumi = { icon = "" } }) end
+  if ok then devicons.set_icon({ nvumi = { icon = "" } }) end
 
   autocmds.setup()
 end

--- a/lua/nvumi/main.lua
+++ b/lua/nvumi/main.lua
@@ -43,7 +43,8 @@ function M.setup()
     require("nvumi.actions").reset_buffer()
   end, {})
 
-  require("nvim-web-devicons").set_icon({ nvumi = { icon = "" } })
+  local ok, devicons = pcall(require, "nvim-web-devicons")
+  if ok then devicons.set_icon({ nvumi = { icon = "" } }) end
 
   autocmds.setup()
 end

--- a/lua/nvumi/scratch.lua
+++ b/lua/nvumi/scratch.lua
@@ -7,19 +7,36 @@ local M = {}
 local bufnr = nil
 local winid = nil
 
+local icon = "󰿉"
+
 local function is_open()
   return winid ~= nil and vim.api.nvim_win_is_valid(winid)
 end
 
 local function build_footer()
   local keys = config.options.keys
-  return string.format(" %s run  %s reset  %s yank  %s yank all ", keys.run, keys.reset, keys.yank, keys.yank_all)
+  local sep = { "  ·  ", "FloatBorder" }
+  return {
+    { " ", "FloatBorder" },
+    { keys.run, "FloatTitle" },
+    { " Run", "Comment" },
+    sep,
+    { keys.reset, "FloatTitle" },
+    { " Reset", "Comment" },
+    sep,
+    { keys.yank, "FloatTitle" },
+    { " Yank", "Comment" },
+    sep,
+    { keys.yank_all, "FloatTitle" },
+    { " Yank all", "Comment" },
+    sep,
+    { "q", "FloatTitle" },
+    { " Close ", "Comment" },
+  }
 end
 
 local function get_or_create_buf()
-  if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
-    return bufnr
-  end
+  if bufnr and vim.api.nvim_buf_is_valid(bufnr) then return bufnr end
 
   bufnr = vim.api.nvim_create_buf(false, true)
 
@@ -30,15 +47,15 @@ local function get_or_create_buf()
   vim.keymap.set("n", keys.yank_all, state.yank_all_outputs, { buffer = bufnr, desc = "nvumi: yank all" })
   vim.keymap.set("n", "q", M.close, { buffer = bufnr, desc = "nvumi: close" })
 
-  -- set filetype last so the FileType autocmd sees a fully configured buffer
+  -- set filetype last
   vim.bo[bufnr].filetype = "nvumi"
 
   return bufnr
 end
 
 local function open_win(buf)
-  local width = math.floor(vim.o.columns * 0.65)
-  local height = math.floor(vim.o.lines * 0.65)
+  local width = math.floor(vim.o.columns * 0.4)
+  local height = math.floor(vim.o.lines * 0.4)
   local row = math.floor((vim.o.lines - height) / 2)
   local col = math.floor((vim.o.columns - width) / 2)
 
@@ -50,11 +67,14 @@ local function open_win(buf)
     col = col,
     style = "minimal",
     border = "rounded",
-    title = " nvumi ",
+    title = { { " " .. icon .. " nvumi ", "FloatTitle" } },
     title_pos = "center",
     footer = build_footer(),
     footer_pos = "center",
   })
+
+  vim.wo[win].scrolloff = 2
+  vim.wo[win].statuscolumn = "  "
 
   vim.api.nvim_create_autocmd("WinClosed", {
     pattern = tostring(win),
@@ -78,9 +98,7 @@ function M.open()
 end
 
 function M.close()
-  if winid and vim.api.nvim_win_is_valid(winid) then
-    vim.api.nvim_win_close(winid, false)
-  end
+  if winid and vim.api.nvim_win_is_valid(winid) then vim.api.nvim_win_close(winid, false) end
   winid = nil
 end
 

--- a/lua/nvumi/scratch.lua
+++ b/lua/nvumi/scratch.lua
@@ -1,0 +1,87 @@
+local actions = require("nvumi.actions")
+local config = require("nvumi.config")
+local state = require("nvumi.state")
+
+local M = {}
+
+local bufnr = nil
+local winid = nil
+
+local function is_open()
+  return winid ~= nil and vim.api.nvim_win_is_valid(winid)
+end
+
+local function build_footer()
+  local keys = config.options.keys
+  return string.format(" %s run  %s reset  %s yank  %s yank all ", keys.run, keys.reset, keys.yank, keys.yank_all)
+end
+
+local function get_or_create_buf()
+  if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+    return bufnr
+  end
+
+  bufnr = vim.api.nvim_create_buf(false, true)
+
+  local keys = config.options.keys
+  vim.keymap.set({ "n", "x" }, keys.run, actions.run_on_buffer, { buffer = bufnr, desc = "nvumi: run" })
+  vim.keymap.set("n", keys.reset, actions.reset_buffer, { buffer = bufnr, desc = "nvumi: reset" })
+  vim.keymap.set("n", keys.yank, state.yank_output_on_line, { buffer = bufnr, desc = "nvumi: yank line" })
+  vim.keymap.set("n", keys.yank_all, state.yank_all_outputs, { buffer = bufnr, desc = "nvumi: yank all" })
+  vim.keymap.set("n", "q", M.close, { buffer = bufnr, desc = "nvumi: close" })
+
+  -- set filetype last so the FileType autocmd sees a fully configured buffer
+  vim.bo[bufnr].filetype = "nvumi"
+
+  return bufnr
+end
+
+local function open_win(buf)
+  local width = math.floor(vim.o.columns * 0.65)
+  local height = math.floor(vim.o.lines * 0.65)
+  local row = math.floor((vim.o.lines - height) / 2)
+  local col = math.floor((vim.o.columns - width) / 2)
+
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = row,
+    col = col,
+    style = "minimal",
+    border = "rounded",
+    title = " nvumi ",
+    title_pos = "center",
+    footer = build_footer(),
+    footer_pos = "center",
+  })
+
+  vim.api.nvim_create_autocmd("WinClosed", {
+    pattern = tostring(win),
+    once = true,
+    callback = function()
+      winid = nil
+    end,
+  })
+
+  return win
+end
+
+function M.open()
+  if is_open() then
+    M.close()
+    return
+  end
+
+  local buf = get_or_create_buf()
+  winid = open_win(buf)
+end
+
+function M.close()
+  if winid and vim.api.nvim_win_is_valid(winid) then
+    vim.api.nvim_win_close(winid, false)
+  end
+  winid = nil
+end
+
+return M

--- a/tests/actions_spec.lua
+++ b/tests/actions_spec.lua
@@ -26,6 +26,7 @@ describe("nvumi.actions", function()
       end,
       nvim_buf_set_lines = function() end,
       nvim_err_writeln = function() end,
+      nvim_echo = function() end,
     }
 
     real_fns = {

--- a/tests/main_spec.lua
+++ b/tests/main_spec.lua
@@ -3,26 +3,23 @@ local main = require("nvumi.main")
 
 describe("nvumi.main", function()
   before_each(function()
-    package.preload["snacks.scratch"] = function()
+    package.preload["nvumi.scratch"] = function()
       return {
-        open = function(opts)
-          _G._TEST_NVUMI_OPEN_OPTS = opts
+        open = function()
+          _G._TEST_NVUMI_SCRATCH_OPENED = true
         end,
       }
     end
   end)
 
   after_each(function()
-    _G._TEST_NVUMI_OPEN_OPTS = nil
-    package.preload["snacks.scratch"] = nil
+    _G._TEST_NVUMI_SCRATCH_OPENED = nil
+    package.preload["nvumi.scratch"] = nil
+    package.loaded["nvumi.scratch"] = nil
   end)
 
   it("should open a scratch buffer when Nvumi is invoked", function()
     main.open()
-    assert.is_truthy(_G._TEST_NVUMI_OPEN_OPTS)
-    assert.are.same("Nvumi", _G._TEST_NVUMI_OPEN_OPTS.name)
-    local keys = _G._TEST_NVUMI_OPEN_OPTS.win_by_ft.nvumi.keys
-    assert.is_truthy(keys["source"])
-    assert.is_truthy(keys["reset"])
+    assert.is_truthy(_G._TEST_NVUMI_SCRATCH_OPENED)
   end)
 end)


### PR DESCRIPTION
* Replaces the snacks.nvim scratch buffer with a self contained implementation
  * nvumi no longer has any required dependencies (other than numi of course!)
* Fixes a couple of nvim 0.12 compatibility issues
* Fixes auto eval not firing in the scratch buffer (long-standing bug)


## Changes

### Snacks dependency removed

snacks.nvim is no longer required. Remove it from your nvumi spec:

```lua
-- before
{
  "josephburgess/nvumi",
  dependencies = { "folke/snacks.nvim" },
  opts = { ... }
}

-- after
{
  "josephburgess/nvumi",
  opts = { ... }
}
```

Of course if you use snacks for other plugins, you don’t need to remove it. nvumi just no longer depends on it.

### Self contained scratch buffer

The scratch buffer is now implemented entirely in Lua using core Neovim APIs:

* Single persistent `nofile` buffer
* Content and variables survive toggling
* Same set up with keybindings as previously

### other compatibility issues and fixes

* Autocmds are now buffer-local and live inside the `FileType nvumi` callback, fixing auto evaluation firing
* a few deprecated functions updated e.g. vim.loop > vim.uv